### PR TITLE
Add optional description field to pop from csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Example: **/home/bob/Documents/bulkupload** or on Windows **C:\Users\bob\Documen
 
 - You need to set the environment variables **DC_USERNAME** (your DocumentCloud username) and **DC_PASSWORD** (your DocumentCloud password) on your system ([Linux](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), [Mac OS X](https://phoenixnap.com/kb/set-environment-variable-mac), [Windows](https://phoenixnap.com/kb/windows-set-environment-variable#ftoc-heading-1)). 
 
-- A CSV file with at least two columns: `title` and one other column for the file names, by default it is `name` or you can specify a different one using `--id_col your_column_name_here` with the script.
+- A CSV file with at least two columns: `title` and one other column for the file names, by default it is `name` or you can specify a different one using `--id_col your_column_name_here` with the script. 
 `title` is a human readable title that you would like for the documents, while `name` is the actual name of the file on your computer. <br /> For example, if I have: /home/bob/Documents/bulkupload/test.pdf, `test` would be the title. <br />
+You may add an optional `description` column with filled in or blank values that will be added as a description for documents you upload. <br />
 You may run the following to generate a CSV file for you given a directory of documents if the title is not important for you to configure: <br />
   ```python3 batch_upload.py -p PROJECT_ID --path PATH --csv CSV_NAME --generate_csv``` <br />
   You would then run the following once more to do the upload: <br />

--- a/batch_upload.py
+++ b/batch_upload.py
@@ -86,14 +86,21 @@ class BatchUploader:
         more efficient, but may cause a 30 minute delay between uploading the file
         and seeing it in the web view.
 
-        Sets the title based on an exptec title column in the CSV
+        Sets the title based on an expected title column in the CSV
 
         Sets the rest of the CSV columns as metadata
         """
 
         doc_dict = dict(zip(self.headers, row))
         title = doc_dict.pop("title")
-        return {
+        
+        # Optional description
+        description = doc_dict.pop("description", None)
+        # Ignore descriptions that are only whitespace
+        if description is not None:
+            description = description.strip()
+
+        payload = {
             "title": title,
             "projects": [self.args.project_id],
             "source": self.args.source,
@@ -101,6 +108,11 @@ class BatchUploader:
             "delayed_index": True,
             "data": doc_dict,
         }
+        # Add description to payload if it is present
+        if description:
+            payload["description"] = description
+
+        return payload
 
     def get_files_from_queue(self, queue):
         """Get files from the queue and convert them into a format suitable for upload


### PR DESCRIPTION
EPIC wanted a way to also set the description of documents using the batch upload script, this should allow them to do so. 